### PR TITLE
Move accepted WISER to article

### DIFF
--- a/article.bib
+++ b/article.bib
@@ -3,6 +3,18 @@
 
 %----- 2024 -----%
 
+@ARTICLE{yin2024wiser,
+  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
+  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
+  year = {2024},
+  month = {11},
+  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
+  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
+  url = {https://slim.gatech.edu/Publications/Public/Journals/Geophysics/2024/yin2024wiser/WISER.html},
+  note = {(Accepted for publication in GEOPHYSICS)},
+  doi = {10.48550/arXiv.2405.10327}
+}
+
 @ARTICLE{orozco2023invnet,
   author = {Rafael Orozco and Philipp A. Witte and Mathias Louboutin and Ali Siahkoohi and Gabrio Rizzuti and Bas Peters and Felix J. Herrmann},
   title = {InvertibleNetworks.jl: A Julia package for scalable normalizing flows},

--- a/article.bib
+++ b/article.bib
@@ -40,7 +40,7 @@
   keywords = {gcs, 4D, time-lapse, ccs, coupled inversion, end-to-end, fluid-flow, inversion, monitoring},
   url = {https://slim.gatech.edu/Publications/Public/Journals/TheLeadingEdge/2024/yin2024tfp/paper.html},
   note = {(The Leading Edge)},
-  doi = {10.48550/arXiv.2403.04083}
+  doi = {10.1190/tle43080544.1}
 }
 
 @ARTICLE{yin2023wise,

--- a/internal.bib
+++ b/internal.bib
@@ -21132,7 +21132,7 @@ efficient and high-fidelity method for posterior inference.},
   keywords = {gcs, 4D, time-lapse, ccs, coupled inversion, end-to-end, fluid-flow, inversion, monitoring},
   url = {https://slim.gatech.edu/Publications/Public/Journals/TheLeadingEdge/2024/yin2024tfp/paper.html},
   note = {(The Leading Edge)},
-  doi = {10.48550/arXiv.2403.04083}
+  doi = {10.1190/tle43080544.1}
 }
 
 @ARTICLE{yin2023wise,

--- a/internal.bib
+++ b/internal.bib
@@ -21087,26 +21087,25 @@ methods from the literature our method stands out as an computationally
 efficient and high-fidelity method for posterior inference.},
   keywords = {Normalizing flows, amortization gap, Bayesian inference, simulation-based inference, amortized variational inference, medical imaging},
   doi = {10.48550/arXiv.2405.05398}
-}
-
-@UNPUBLISHED{yin2024wiser,
-  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
-  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
-  year = {2024},
-  month = {5},
-  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
-  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
-  url = {https://slim.gatech.edu/Publications/Public/Submitted/2024/yin2024wiser/WISER.html},
-  doi = {10.13140/RG.2.2.34906.15044}
-}
-
-%-----2023-----%% This file was created with JabRef 2.6.
+}% This file was created with JabRef 2.6.
 % Encoding: MacRoman
 
 % This file was created with JabRef 2.8.1.
 % Encoding: MacRoman
 
 %----- 2024 -----%
+
+@ARTICLE{yin2024wiser,
+  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
+  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
+  year = {2024},
+  month = {11},
+  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
+  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
+  url = {https://slim.gatech.edu/Publications/Public/Journals/Geophysics/2024/yin2024wiser/WISER.html},
+  note = {(Accepted for publication in GEOPHYSICS)},
+  doi = {10.48550/arXiv.2405.10327}
+}
 
 @ARTICLE{orozco2023invnet,
   author = {Rafael Orozco and Philipp A. Witte and Mathias Louboutin and Ali Siahkoohi and Gabrio Rizzuti and Bas Peters and Felix J. Herrmann},

--- a/slimbib.bib
+++ b/slimbib.bib
@@ -21132,7 +21132,7 @@ efficient and high-fidelity method for posterior inference.},
   keywords = {gcs, 4D, time-lapse, ccs, coupled inversion, end-to-end, fluid-flow, inversion, monitoring},
   url = {https://slim.gatech.edu/Publications/Public/Journals/TheLeadingEdge/2024/yin2024tfp/paper.html},
   note = {(The Leading Edge)},
-  doi = {10.48550/arXiv.2403.04083}
+  doi = {10.1190/tle43080544.1}
 }
 
 @ARTICLE{yin2023wise,

--- a/slimbib.bib
+++ b/slimbib.bib
@@ -21087,26 +21087,25 @@ methods from the literature our method stands out as an computationally
 efficient and high-fidelity method for posterior inference.},
   keywords = {Normalizing flows, amortization gap, Bayesian inference, simulation-based inference, amortized variational inference, medical imaging},
   doi = {10.48550/arXiv.2405.05398}
-}
-
-@UNPUBLISHED{yin2024wiser,
-  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
-  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
-  year = {2024},
-  month = {5},
-  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
-  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
-  url = {https://slim.gatech.edu/Publications/Public/Submitted/2024/yin2024wiser/WISER.html},
-  doi = {10.13140/RG.2.2.34906.15044}
-}
-
-%-----2023-----%% This file was created with JabRef 2.6.
+}% This file was created with JabRef 2.6.
 % Encoding: MacRoman
 
 % This file was created with JabRef 2.8.1.
 % Encoding: MacRoman
 
 %----- 2024 -----%
+
+@ARTICLE{yin2024wiser,
+  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
+  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
+  year = {2024},
+  month = {11},
+  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
+  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
+  url = {https://slim.gatech.edu/Publications/Public/Journals/Geophysics/2024/yin2024wiser/WISER.html},
+  note = {(Accepted for publication in GEOPHYSICS)},
+  doi = {10.48550/arXiv.2405.10327}
+}
 
 @ARTICLE{orozco2023invnet,
   author = {Rafael Orozco and Philipp A. Witte and Mathias Louboutin and Ali Siahkoohi and Gabrio Rizzuti and Bas Peters and Felix J. Herrmann},

--- a/unpublished.bib
+++ b/unpublished.bib
@@ -58,16 +58,3 @@ efficient and high-fidelity method for posterior inference.},
   keywords = {Normalizing flows, amortization gap, Bayesian inference, simulation-based inference, amortized variational inference, medical imaging},
   doi = {10.48550/arXiv.2405.05398}
 }
-
-@UNPUBLISHED{yin2024wiser,
-  author = {Ziyi Yin and Rafael Orozco and Felix J. Herrmann},
-  title = {WISER: multimodal variational inference for full-waveform inversion without dimensionality reduction},
-  year = {2024},
-  month = {5},
-  abstract = {We present a semi-amortized variational inference framework designed for computationally feasible uncertainty quantification in 2D full-waveform inversion to explore the multimodal posterior distribution without dimensionality reduction. The framework is called WISER, short for full-Waveform variational Inference via Subsurface Extensions with Refinements. WISER leverages the power of generative artificial intelligence to perform approximate amortized inference that is low-cost albeit showing an amortization gap. This gap is closed through non-amortized refinements that make frugal use of acoustic wave physics. Case studies illustrate that WISER is capable of full-resolution, computationally feasible, and reliable uncertainty estimates of velocity models and imaged reflectivities.},
-  keywords = {WISER, WISE, FWI, imaging, CIG, conditional normalizing flows, Bayesian inference, amortized variational inference, uncertainty quantification, deep learning, inverse problems, summary statistics, MVA},
-  url = {https://slim.gatech.edu/Publications/Public/Submitted/2024/yin2024wiser/WISER.html},
-  doi = {10.13140/RG.2.2.34906.15044}
-}
-
-%-----2023-----%


### PR DESCRIPTION
Could you do me a favor by moving the WISER folder (in dropbox) from
https://slim.gatech.edu/Publications/Public/Submitted/2024/yin2024wiser
to
https://slim.gatech.edu/Publications/Public/Journals/Geophysics/2024/yin2024wiser

and then merge this PR and import the `internal.bib` on SLIM website? Thank you in advance.